### PR TITLE
Catch DatabaseError as well

### DIFF
--- a/graphene_django_extras/paginations/utils.py
+++ b/graphene_django_extras/paginations/utils.py
@@ -2,7 +2,7 @@
 from functools import partial
 
 import graphene
-from django.core.exceptions import ValidationError
+from django.db import DatabaseError
 
 from ..base_types import DjangoListObjectBase
 
@@ -72,5 +72,5 @@ def _get_count(queryset):
     """
     try:
         return queryset.count()
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, DatabaseError):
         return len(queryset)


### PR DESCRIPTION
Adding a `.count()` can sometimes change the sql in ways that lead to syntax errors which raise `DatabaseError`s instead of `AttributeError` or `TypeError`. This change just adds fallback handling for those cases.